### PR TITLE
Add guest-related actions to logged events

### DIFF
--- a/v6/enterprise/audit_logs.md
+++ b/v6/enterprise/audit_logs.md
@@ -9,7 +9,9 @@ warning: false
 Audit logs is an Enterprise-only feature that lists important team events. An admin can review audit logs to determine:
 
 * When users were added to the team.
+* When guests were added to a workspace.
 * When users received an invitation to a team. 
+* When guests received an invitation to a team workspace.
 * Which user performed a specific action.
 
 Audit logs currently include events for team management, billing, and security. In the future, we'll enable events for publishing documentation, creating API keys, and creating monitors.
@@ -37,7 +39,9 @@ The table below lists currently logged events.
 | Added Domain   | A custom domain was added to your team. (You can use custom domains to publish documentation.)  |
 | Deleted Domain  | A custom domain was deleted from your team.  |
 | Added Member   | A user joined your team.   |
+| Added Guest   | A guest joined a team workspace. |
 | Cancelled Invite   | An invitation for a user was cancelled.   |
+| Cancelled Guest Invite | An invitation for a guest was cancelled.|
 | Custom auth scheme created| 	A new SSO scheme was added to your team.  |
 | Custom auth scheme disabled  | An SSO scheme was disabled. |
 | Custom auth scheme enabled | An SSO scheme was enabled.  |
@@ -48,8 +52,10 @@ The table below lists currently logged events.
 | Set Instructions For Next Billing Cycle  | Instructions for the next billing cycle were added.|
 | Team name changed  | Team name was changed.  |
 | Removed Member  | 	Team member was removed.  |
+| Removed Guest   | Team guest was removed.   |
 | Successfully Retried Invoice  | An invoice for your team was paid.  |
 | Sent Invite  | An invitation was sent to a user to join your team.  |
+| Sent Guest Invite   | An invitation was sent to a guest to join a team workspace.   |
 | Started Pro  | Your Enterprise plan has started.  |
 | Updated domain verification  | A domain’s verification status was updated.|
 | Updated User Roles | Roles were updated for some users in your team.  |


### PR DESCRIPTION
Addition of logged actions an admin may take in regards to a guest on their Postman team.